### PR TITLE
Make Lookup1 more resilient

### DIFF
--- a/pkg/resolvers/doq.go
+++ b/pkg/resolvers/doq.go
@@ -194,8 +194,12 @@ func (r *DOQResolver) Lookup1(question dns.Question) ([]dns.Msg, error) {
 			return nil, err
 		}
 
-		var buf []byte
-		buf, err = io.ReadAll(stream)
+		// Use this other than io.ReadAll to prevent losing io.EOF error.
+		// Once we figure out why quic-go server sends io.EOF after running
+		// for a long time, we can have a better way to handle this. For now,
+		// make sure io.EOF error returned, so the caller can handle it cleanly.
+		buf := make([]byte, msgLen+2)
+		_, err = io.ReadFull(stream, buf)
 		if err != nil {
 			if errors.Is(err, os.ErrDeadlineExceeded) {
 				return nil, fmt.Errorf("timeout")

--- a/pkg/resolvers/doq.go
+++ b/pkg/resolvers/doq.go
@@ -1,6 +1,7 @@
 package resolvers
 
 import (
+	"context"
 	"crypto/tls"
 	"encoding/binary"
 	"errors"
@@ -170,7 +171,7 @@ func (r *DOQResolver) Lookup1(question dns.Question) ([]dns.Msg, error) {
 		}
 
 		var stream quic.Stream
-		stream, err = session.OpenStream()
+		stream, err = session.OpenStreamSync(context.Background())
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/resolvers/doq.go
+++ b/pkg/resolvers/doq.go
@@ -152,6 +152,7 @@ func (r *DOQResolver) Lookup1(question dns.Question) ([]dns.Msg, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer udpConn.Close()
 
 	session, err := quic.Dial(udpConn, udpAddr, r.server, r.tls, nil)
 	if err != nil {


### PR DESCRIPTION
This PR make Lookup1 more resilient:

 - Prevent fd leaking by always closing udp connection.
 - Using OpenStreamSync to make sure the stream is available before using.
 - Using io.ReadFull to detect strange behavior from quic-go server: sending io.EOF even the stream is good.