### PR TITLE
pkg/resolvers: fix message length mismatch

### DIFF
--- a/pkg/resolvers/doq.go
+++ b/pkg/resolvers/doq.go
@@ -194,24 +194,25 @@ func (r *DOQResolver) Lookup1(question dns.Question) ([]dns.Msg, error) {
 			return nil, err
 		}
 
-		// Use this other than io.ReadAll to prevent losing io.EOF error.
-		// Once we figure out why quic-go server sends io.EOF after running
-		// for a long time, we can have a better way to handle this. For now,
-		// make sure io.EOF error returned, so the caller can handle it cleanly.
-		buf := make([]byte, msgLen+2)
-		_, err = io.ReadFull(stream, buf)
+		buf, err := io.ReadAll(stream)
 		if err != nil {
 			if errors.Is(err, os.ErrDeadlineExceeded) {
 				return nil, fmt.Errorf("timeout")
 			}
 			return nil, err
 		}
-
+		// io.ReadAll hide the io.EOF error returned by quic-go server.
+		// Once we figure out why quic-go server sends io.EOF after running
+		// for a long time, we can have a better way to handle this. For now,
+		// make sure io.EOF error returned, so the caller can handle it cleanly.
+		if len(buf) == 0 {
+			return nil, io.EOF
+		}
 		_ = stream.Close()
 
 		packetLen := binary.BigEndian.Uint16(buf[:2])
 		if packetLen != uint16(len(buf[2:])) {
-			return nil, fmt.Errorf("packet length mismatch")
+			return nil, fmt.Errorf("packet length mismatch,got: %d, want: %d", packetLen, len(buf[2:]))
 		}
 		if err := msg.Unpack(buf[2:]); err != nil {
 			return nil, err


### PR DESCRIPTION
In previous commit, we change from io.ReadAll to io.ReadFull, to keep the io.EOF error. However, the message length sent by client may not have the same length as the response message from server. The quic-go example can use io.ReadFull, because it always knows exactly the length of the response message.

Instead, we can detect if we got an empty buf in case of no error, and return io.EOF error to the caller instead.