### PR TITLE
DOT+DOH: support for root-cas file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.so
 *.dylib
 dist/
+.idea/
 
 # Test binary, built with `go test -c`
 *.test

--- a/cmd/doggo/help.go
+++ b/cmd/doggo/help.go
@@ -57,6 +57,7 @@ var appHelpTextTemplate = `{{ "NAME" | color "" "heading" }}:
   {{"--tls-hostname=HOSTNAME" | color "yellow" ""}}      Provide a hostname for doing verification of the certificate if the provided DoT nameserver is an IP.
   {{"--skip-hostname-verification" | color "yellow" ""}} Skip TLS Hostname Verification in case of DOT Lookups.
   {{"--header" | color "yellow" ""}}                     HTTP headers to supply to the resolver. Can supply multiple times.
+  {{"--root-cas=FILE" | color "yellow" ""}}              Root CAs file to use for TLS verification.
 
 {{ "Output Options" | color "" "heading" }}:
   {{"-J, --json " | color "yellow" ""}}                 Format the output as JSON.

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -40,6 +40,7 @@ type QueryFlags struct {
 	Strategy           string        `koanf:"strategy" strategy:"-"`
 	InsecureSkipVerify bool          `koanf:"skip-hostname-verification" skip-hostname-verification:"-"`
 	TLSHostname        string        `koanf:"tls-hostname" tls-hostname:"-"`
+	RootCAs            string        `koanf:"root-cas"`
 }
 
 // Nameserver represents the type of Nameserver

--- a/pkg/resolvers/classic.go
+++ b/pkg/resolvers/classic.go
@@ -46,6 +46,7 @@ func NewClassicResolver(server string, classicOpts ClassicResolverOpts, resolver
 		client.TLSConfig = &tls.Config{
 			ServerName:         resolverOpts.TLSHostname,
 			InsecureSkipVerify: resolverOpts.InsecureSkipVerify,
+			RootCAs:            resolverOpts.RootCAs,
 		}
 	}
 

--- a/pkg/resolvers/doh.go
+++ b/pkg/resolvers/doh.go
@@ -41,6 +41,7 @@ func NewDOHResolver(server string, resolverOpts Options, doh3 bool) (Resolver, e
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: resolverOpts.InsecureSkipVerify,
+				RootCAs:            resolverOpts.RootCAs,
 			},
 		},
 	}
@@ -49,6 +50,7 @@ func NewDOHResolver(server string, resolverOpts Options, doh3 bool) (Resolver, e
 		httpClient.Transport = &http3.RoundTripper{
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: resolverOpts.InsecureSkipVerify,
+				RootCAs:            resolverOpts.RootCAs,
 			},
 		}
 	}

--- a/pkg/resolvers/doq.go
+++ b/pkg/resolvers/doq.go
@@ -28,6 +28,7 @@ func NewDOQResolver(server string, resolverOpts Options) (Resolver, error) {
 	return &DOQResolver{
 		tls: &tls.Config{
 			NextProtos: []string{"doq"},
+			RootCAs:    resolverOpts.RootCAs,
 		},
 		server:          server,
 		resolverOptions: resolverOpts,

--- a/pkg/resolvers/resolver.go
+++ b/pkg/resolvers/resolver.go
@@ -1,6 +1,7 @@
 package resolvers
 
 import (
+	"crypto/x509"
 	"net/http"
 	"time"
 
@@ -24,6 +25,7 @@ type Options struct {
 	InsecureSkipVerify bool
 	TLSHostname        string
 	Headers            http.Header
+	RootCAs            *x509.CertPool
 }
 
 // Resolver implements the configuration for a DNS


### PR DESCRIPTION
DoQ and DoH/3 nameservers aren't always served with TLS certs rooted in known, public sources of trust.

This PR adds support for configuring custom `RootCAs` on DOH and DOT resolvers.